### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is an enhanced version of the [original Markdownify MCP project](https://gi
 
 [中文文档](README-CN.md)
 
+<a href="https://glama.ai/mcp/servers/51hyoj300s">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/51hyoj300s/badge" alt="Markdownify Server - UTF-8 Enhanced MCP server" />
+</a>
+
 ## Enhancements
 
 - Added comprehensive UTF-8 encoding support
@@ -296,4 +300,4 @@ Contributions are welcome! Before submitting a Pull Request, please:
 For issues or suggestions:
 1. Submit an Issue: https://github.com/JDJR2024/markdownify-mcp-utf8/issues
 2. Create a Pull Request: https://github.com/JDJR2024/markdownify-mcp-utf8/pulls
-3. Email: jdidndosmmxmx@gmail.com 
+3. Email: jdidndosmmxmx@gmail.com


### PR DESCRIPTION
This PR adds a badge for the [Markdownify MCP Server - UTF-8 Enhanced](https://glama.ai/mcp/servers/51hyoj300s) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/51hyoj300s">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/51hyoj300s/badge" alt="Markdownify Server - UTF-8 Enhanced MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.